### PR TITLE
Removing assumption of Lua install directory

### DIFF
--- a/sys-1.1-0.rockspec
+++ b/sys-1.1-0.rockspec
@@ -20,6 +20,6 @@ dependencies = {
 
 build = {
    type = "command",
-   build_command = [[cmake -E make_directory build && cd build && cmake .. -DLUALIB=$(LUALIB) -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE)]],
+   build_command = [[cmake -E make_directory build && cd build && cmake .. -DLUALIB=$(LUALIB) -DCMAKE_BUILD_TYPE=Release  -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE)]],
    install_command = "cd build && $(MAKE) install"
 }


### PR DESCRIPTION
Passed -DCMAKE_PREFIX_PATH="$(SCRIPTS_DIR)/.. instead of LUA_BINDIR as Lua may be external
